### PR TITLE
add regex matching support

### DIFF
--- a/nginx-redirect/nginx-templates/default.conf.template
+++ b/nginx-redirect/nginx-templates/default.conf.template
@@ -1,7 +1,18 @@
-map $http_host $redir_to {
+map $host$request_uri $redir_to {
     default "not-found";
-{{- range $shost, $dhost := .Values.redirects }}
-    {{ $shost }} {{ quote $dhost }};
+{{- range $src, $dst := .Values.redirects }}
+{{- if hasPrefix "^" $src }}
+    {{ printf "~%s" $src }} {{ quote $dst }};
+{{- end }}
+{{- end }}
+}
+
+map $host $redir_host_to {
+    default "not-found";
+{{- range $src, $dst := .Values.redirects }}
+{{- if not (hasPrefix "^" $src) }}
+    {{ quote $src }} {{ quote $dst }};
+{{- end }}
 {{- end }}
 }
 
@@ -10,12 +21,14 @@ server {
     server_name  localhost default_server;
 
     location / {
-        if ($redir_to = "not-found") {
-            add_header Content/Type text/plain;
-
-            return 404;
+        if ($redir_to != "not-found") {
+            return 301 $redir_to;
         }
 
-        return 301 $redir_to;
+        if ($redir_host_to != "not-found") {
+            return 301 $redir_host_to;
+        }
+
+        return 404;
     }
 }

--- a/nginx-redirect/values.yaml
+++ b/nginx-redirect/values.yaml
@@ -1,5 +1,6 @@
 redirects: {}
 # redirect.host: https://redirect/url
+# ^redirect.host/path$: https://redirect/url
 
 nameOverride: ""
 fullnameOverride: ""
@@ -24,4 +25,4 @@ ingress:
 
   annotations: {}
   hosts: []
-  tls: {}
+  tls: []


### PR DESCRIPTION
This adds support for defining a regex matched redirect. Entries which start with `^` will use regex instead of simple host matching.