### PR TITLE
fix(ci): set the semantic commit type

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     "customManagers:helmChartYamlAppVersions",
-    ":semanticCommits"
+    ":semanticCommits",
+    ":semanticCommitTypeAll(ci)"
   ],
   "postUpdateOptions": [
     "helmUpdateSubChartArchives"


### PR DESCRIPTION
renovate frequently uses chore which results in versions not being bumped.

this should ensure the version is bumped